### PR TITLE
Add a scope option to the query

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ If a model has a large number of columns and you only want to export a subset of
 php artisan model:export User --only-fields=name,email
 ```
 
+### Apply a specific scope to the query
+
+If you wish to apply a scope to the model query because you wish to exclude certain records, you can use the `--scope={scope}` option. This allows you to specify a scope for the records you want to include in the export. For example:
+
+```bash
+php artisan model:export User --scope=verified
+```
+
+On your User Model you would have the following function:
+
+```php
+    public function scopeVerified(Builder $query): void
+    {
+        $query->whereNotNull('email_verified_at');
+    }
+```
+
 ### Relationships
 
 You can now export models along with their specified relationships using the new option `--with-relationships={relations}`. `{relations}` are the names of the relationships and can be separated by `+` symbol if you want to attach more than one relationship.

--- a/src/Commands/ExportModelData.php
+++ b/src/Commands/ExportModelData.php
@@ -35,6 +35,7 @@ class ExportModelData extends BaseCommand
 
         $exportService = ExportService::make()
             ->setModel($modelClass)
+            ->setScope($this->option('scope'))
             ->setFilename($this->option('filename'))
             ->setPath($this->option('path'))
             ->setExceptColumns($this->option('except-fields'))
@@ -79,6 +80,7 @@ class ExportModelData extends BaseCommand
             ['without-timestamps', null, InputOption::VALUE_NONE, 'Export without: created_at, updated_at and deleted_at columns'],
             ['beautify', '-b', InputOption::VALUE_NONE, 'Beautify JSON'],
             ['with-relationships', null, InputOption::VALUE_OPTIONAL, 'Relationships to include (plus-separator)'],
+            ['scope', null, InputOption::VALUE_OPTIONAL, 'Scope you wish to apply to the query'],
         ];
     }
 }

--- a/src/Traits/HasModel.php
+++ b/src/Traits/HasModel.php
@@ -54,10 +54,6 @@ trait HasModel
     {
         $this->scope = $scope;
 
-        if (!is_null($this->scope) && !method_exists($this->model, 'scope'.ucfirst($this->scope))) {
-            throw new BadMethodCallException('Scope ' . $this->scope . ' does not exists.');
-        }
-
         return $this;
     }
 
@@ -78,7 +74,7 @@ trait HasModel
             ->when(filled($relations = $this->getRelationships()), function (Builder $builder) use ($relations) {
                 $builder->with($relations);
             })
-            ->when(!is_null($scope = $this->scope), function (Builder $builder) use ($scope) {
+            ->when(filled($scope = $this->scope), function (Builder $builder) use ($scope) {
                 $builder->$scope();
             });
     }

--- a/src/Traits/HasModel.php
+++ b/src/Traits/HasModel.php
@@ -2,7 +2,7 @@
 
 namespace Vildanbina\ModelJson\Traits;
 
-use http\Exception\BadMethodCallException;
+use BadMethodCallException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;

--- a/src/Traits/HasModel.php
+++ b/src/Traits/HasModel.php
@@ -46,15 +46,15 @@ trait HasModel
     }
 
     /**
-     * @param  string  $scope
+     * @param  ?string  $scope
      *
      * @return $this
      */
-    public function setScope(string $scope): static
+    public function setScope(?string $scope): static
     {
         $this->scope = $scope;
 
-        if (!method_exists($this->model, 'scope'.ucfirst($this->scope))) {
+        if (!is_null($this->scope) && !method_exists($this->model, 'scope'.ucfirst($this->scope))) {
             throw new BadMethodCallException('Scope ' . $this->scope . ' does not exists.');
         }
 


### PR DESCRIPTION
This PR adds the ability to use the `--scope={scope}` option on exports.
If you have defined a scope on your model for example:
```php
    public function scopeActive(Builder $query): void
    {
        return $query->where('active', true);
    }
```
passing `--scope=active` to the export assures you only export the active models.