### PR TITLE
Add `--with-hidden` option to include hidden fields in the export

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ To exclude the `created_at`, `updated_at`, and `deleted_at` columns from the exp
 php artisan model:export User --without-timestamps
 ```
 
+### Without global scopes
+
+You can remove registered global scopes from the export with the `--without-global-scopes` option. For example:
+
+```bash
+php artisan model:export User --without-global-scopes
+```
+
+### With hidden
+
+By default, only visible fields are included in the export. To also include all hidden fields in the export, use the `--with-hidden` option. For example:
+
+```bash
+php artisan model:export User --with-hidden
+```
+
+This will also apply to any included relation(s) if used in combination with the `--with-relationships` option.
+
 ### Select only specific fields
 
 If a model has a large number of columns and you only want to export a subset of them, you can use the `--only-fields` option. This allows you to specify which columns you want to include in the export. For example:

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,12 @@
     }
   ],
   "require": {
-    "php": "^8.0|^8.1",
+    "php": "^8.1",
     "spatie/laravel-package-tools": "^1.13"
+  },
+  "require-dev": {
+    "illuminate/database": "^11.0",
+    "illuminate/console": "^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Commands/ExportModelData.php
+++ b/src/Commands/ExportModelData.php
@@ -17,15 +17,16 @@ class ExportModelData extends BaseCommand
      * @var string
      */
     protected $name = 'model:export';
+
     /**
      * @var string
      */
     protected $description = 'Export any Model\'s data into JSON.';
 
     /**
-     * @return int|mixed
+     * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         $modelClass = $this->qualifyModel($this->argument('model'));
 
@@ -41,6 +42,8 @@ class ExportModelData extends BaseCommand
             ->setExceptColumns($this->option('except-fields'))
             ->setOnlyColumns($this->option('only-fields'))
             ->withoutTimestamps($this->option('without-timestamps'))
+            ->withoutGlobalScopes($this->option('without-global-scopes'))
+            ->withHidden($this->option('with-hidden'))
             ->setRelationships($this->option('with-relationships'))
             ->beautifyJson($this->option('beautify') ?: false)
             ->onEach(function () {
@@ -54,7 +57,7 @@ class ExportModelData extends BaseCommand
 
         $this->output->success('Your model\'s JSON data has been saved to "' . $path . '"');
 
-        return Command::SUCCESS;
+        return static::SUCCESS;
     }
 
     /**
@@ -78,6 +81,8 @@ class ExportModelData extends BaseCommand
             ['except-fields', null, InputOption::VALUE_OPTIONAL, 'Columns that you do not want to save in the JSON file.'],
             ['only-fields', null, InputOption::VALUE_OPTIONAL, 'Only columns that you want to save in a JSON file.'],
             ['without-timestamps', null, InputOption::VALUE_NONE, 'Export without: created_at, updated_at and deleted_at columns'],
+            ['without-global-scopes', null, InputOption::VALUE_NONE, 'Export without global scopes'],
+            ['with-hidden', null, InputOption::VALUE_NONE, 'Export including all hidden columns'],
             ['beautify', '-b', InputOption::VALUE_NONE, 'Beautify JSON'],
             ['with-relationships', null, InputOption::VALUE_OPTIONAL, 'Relationships to include (plus-separator)'],
             ['scope', null, InputOption::VALUE_OPTIONAL, 'Scope you wish to apply to the query'],

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -2,7 +2,8 @@
 
 namespace Vildanbina\ModelJson\Services;
 
-use Arr;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Vildanbina\ModelJson\Traits\ColumnManipulator;
 use Vildanbina\ModelJson\Traits\EachClosure;
 use Vildanbina\ModelJson\Traits\HasDestinationPath;
@@ -47,10 +48,10 @@ class ExportService extends JsonService
     {
         $data = [];
 
-        $this->modelQuery()->chunkMap(function ($model) use (&$data) {
+        $this->modelQuery()->chunkMap(function (Model $model) use (&$data) {
             $value = filled($this->onlyColumns) ?
-                Arr::only($model->toArray(), $this->onlyColumns) :
-                Arr::except($model->toArray(), $this->exceptColumns);
+                Arr::only($this->serialize($model), $this->onlyColumns) :
+                Arr::except($this->serialize($model), $this->exceptColumns);
 
             if ($this->withoutTimestamps) {
                 $value = Arr::except($value, static::$timestampsField);

--- a/src/Traits/HasModel.php
+++ b/src/Traits/HasModel.php
@@ -26,6 +26,11 @@ trait HasModel
     protected ?string $scope = null;
 
     /**
+     * @var bool
+     */
+    protected bool $withoutGlobalScopes = false;
+
+    /**
      * @param  string  $model
      *
      * @return $this
@@ -57,6 +62,13 @@ trait HasModel
         return $this;
     }
 
+    public function withoutGlobalScopes(bool $withoutGlobalScopes = true): static
+    {
+        $this->withoutGlobalScopes = $withoutGlobalScopes;
+
+        return $this;
+    }
+
     /**
      * @return int
      */
@@ -71,6 +83,9 @@ trait HasModel
     protected function modelQuery(): Builder
     {
         return $this->model::query()
+            ->when($this->withoutGlobalScopes, function (Builder $builder) {
+                $builder->withoutGlobalScopes();
+            })
             ->when(filled($relations = $this->getRelationships()), function (Builder $builder) use ($relations) {
                 $builder->with($relations);
             })


### PR DESCRIPTION
This PR adds a `--with-hidden` option for model exports to include all hidden fields. This also applies to relations that are included in the export with the `--with-relationships={relations}` option.

Additionally, this PR adds a `--without-global-scopes` option to remove registered global scopes from the export.