### PR TITLE
Add arguments support to the `--scope` export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,27 @@ If you wish to apply a scope to the model query because you wish to exclude cert
 php artisan model:export User --scope=verified
 ```
 
-On your User Model you would have the following function:
+On your `User` model you would have the following method:
 
 ```php
     public function scopeVerified(Builder $query): void
     {
         $query->whereNotNull('email_verified_at');
+    }
+```
+
+The `--scope` option also supports one or more arguments to be passed to the scope, comma separated. For example:
+
+```bash
+php artisan model:export User --scope=byEmail,foo@example.com
+```
+
+On your `User` model you would have the following method:
+
+```php
+    public function scopeByEmail(Builder $query, string $email): void
+    {
+        $query->where('email', $email);
     }
 ```
 

--- a/src/Traits/HasModel.php
+++ b/src/Traits/HasModel.php
@@ -75,7 +75,9 @@ trait HasModel
                 $builder->with($relations);
             })
             ->when(filled($scope = $this->scope), function (Builder $builder) use ($scope) {
-                $builder->$scope();
+                $args = explode(',', $scope);
+                $scopeName = array_shift($args);
+                empty($args) ? $builder->$scopeName() : $builder->$scopeName(...$args);
             });
     }
 }


### PR DESCRIPTION
This PR adds arguments support to the `--scope` export option. Instead of just `--scope={scope}` we could now also use `--scope={scope},{arg1},{arg2}`.

I think this is a crucial feature for this package, as currently there's no way to modify the default `modelQuery()` in `ExportService`. With a custom scope that accepts arguments, you could limit the export to a subset of models dynamically by passing the extra argument(s) directly via the `--scope` option.