### PR TITLE
Add `--forget-data` option to exclude data from import/export by dot notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ If a model has a large number of columns and you only want to export a subset of
 php artisan model:export User --only-fields=name,email
 ```
 
+### Forget data
+
+You can forget data from the export by using the dot notation, accepting wildcards using asterisks. For example:
+
+```bash
+php artisan model:export Post --forget-data=comments.*.moderated_at
+```
+
+This can be useful if you include relations with the `--with-relationships` option and you would like to remove `chaperone()`'d relations from the nested data.
+
+The `--forget-data` option supports one or more keys, comma separated.
+
 ### Apply a specific scope to the query
 
 If you wish to apply a scope to the model query because you wish to exclude certain records, you can use the `--scope={scope}` option. This allows you to specify a scope for the records you want to include in the export. For example:
@@ -168,6 +180,16 @@ If you only want to store specific fields, you can use the `--only-fields` optio
 ```bash
 php artisan model:import User public/Users.json --only-fields=first_name,last_name,email
 ```
+
+## Forget data
+
+You can forget data from the import by using the dot notation, accepting wildcards using asterisks. For example:
+
+```bash
+php artisan model:import Post public/Posts.json --forget-data=comments.*.moderated_at
+```
+
+The `--forget-data` option supports one or more keys, comma separated.
 
 ## Update existing records
 

--- a/src/Commands/ExportModelData.php
+++ b/src/Commands/ExportModelData.php
@@ -40,6 +40,7 @@ class ExportModelData extends BaseCommand
             ->setPath($this->option('path'))
             ->setExceptColumns($this->option('except-fields'))
             ->setOnlyColumns($this->option('only-fields'))
+            ->setForgetData($this->option('forget-data'))
             ->withoutTimestamps($this->option('without-timestamps'))
             ->setRelationships($this->option('with-relationships'))
             ->beautifyJson($this->option('beautify') ?: false)
@@ -77,6 +78,7 @@ class ExportModelData extends BaseCommand
             ['filename', null, InputOption::VALUE_OPTIONAL, 'Filename of JSON file'],
             ['except-fields', null, InputOption::VALUE_OPTIONAL, 'Columns that you do not want to save in the JSON file.'],
             ['only-fields', null, InputOption::VALUE_OPTIONAL, 'Only columns that you want to save in a JSON file.'],
+            ['forget-data', null, InputOption::VALUE_OPTIONAL, 'Keys that you want to remove from the JSON data. Comma-separated, supporting dot notation.'],
             ['without-timestamps', null, InputOption::VALUE_NONE, 'Export without: created_at, updated_at and deleted_at columns'],
             ['beautify', '-b', InputOption::VALUE_NONE, 'Beautify JSON'],
             ['with-relationships', null, InputOption::VALUE_OPTIONAL, 'Relationships to include (plus-separator)'],

--- a/src/Commands/ImportModelData.php
+++ b/src/Commands/ImportModelData.php
@@ -38,6 +38,7 @@ class ImportModelData extends BaseCommand
             ->setPath($this->argument('path'))
             ->setExceptColumns($this->option('except-fields'))
             ->setOnlyColumns($this->option('only-fields'))
+            ->setForgetData($this->option('forget-data'))
             ->updateWhenExists($this->option('update-when-exists'))
             ->updateKeys($this->option('update-keys'))
             ->withoutTimestamps($this->option('without-timestamps'))
@@ -77,6 +78,7 @@ class ImportModelData extends BaseCommand
             ['update-keys', null, InputOption::VALUE_OPTIONAL, 'Attributes of the model used to check if a record exists.'],
             ['except-fields', null, InputOption::VALUE_OPTIONAL, 'Columns that you do not want to save in the JSON file.'],
             ['only-fields', null, InputOption::VALUE_OPTIONAL, 'Only columns that you want to save in a JSON file.'],
+            ['forget-data', null, InputOption::VALUE_OPTIONAL, 'Keys that you want to remove from the JSON data. Comma-separated, supporting dot notation.'],
             ['without-timestamps', null, InputOption::VALUE_NONE, 'Export without: created_at, updated_at and deleted_at columns'],
             ['with-relationships', null, InputOption::VALUE_OPTIONAL, 'Relationships to include (plus-separator)'],
         ];

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -4,6 +4,7 @@ namespace Vildanbina\ModelJson\Services;
 
 use Arr;
 use Vildanbina\ModelJson\Traits\ColumnManipulator;
+use Vildanbina\ModelJson\Traits\DataManipulator;
 use Vildanbina\ModelJson\Traits\EachClosure;
 use Vildanbina\ModelJson\Traits\HasDestinationPath;
 use Vildanbina\ModelJson\Traits\HasFilename;
@@ -21,6 +22,7 @@ class ExportService extends JsonService
     use HasFilename;
     use HasDestinationPath;
     use ColumnManipulator;
+    use DataManipulator;
     use HasRelationships;
     use EachClosure;
 
@@ -59,6 +61,10 @@ class ExportService extends JsonService
             if (is_callable($this->onEach)) {
                 value($this->onEach, $value);
             }
+
+            collect($this->forgetKeys)->each(function (string|array|int $key) use (&$value) {
+                data_forget($value, $key);
+            });
 
             $data[] = $value;
         });

--- a/src/Traits/DataManipulator.php
+++ b/src/Traits/DataManipulator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Vildanbina\ModelJson\Traits;
+
+/**
+ * Trait DataManipulator
+ *
+ * @package Vildanbina\ModelJson\Traits
+ */
+trait DataManipulator
+{
+    protected array $forgetKeys = [];
+
+    /**
+     * @param  string|array|null  $forgetKeys
+     *
+     * @return $this
+     */
+    public function setForgetData(null|string|array $forgetKeys): static
+    {
+        if (filled($forgetKeys)) {
+            $this->forgetKeys = is_string($forgetKeys)
+                ? explode(',', $forgetKeys)
+                : $forgetKeys;
+        }
+
+        return $this;
+    }
+}

--- a/src/Traits/HasModel.php
+++ b/src/Traits/HasModel.php
@@ -16,7 +16,7 @@ use LogicException;
 trait HasModel
 {
     /**
-     * @var string
+     * @var class-string<Model>
      */
     protected string $model;
 


### PR DESCRIPTION
Add a `--forget-data` option to exclude data from import/export by dot notation, supporting one or more keys, comma separated. We're using Laravel's [`data_forget()`](https://laravel.com/docs/11.x/helpers#method-data-forget) helper which also supports dot notation with wildcards using asterisks.

As I didn't find a way to globally disable `chaperone()` on all relations, this is a viable option to get rid of any sub-relations which don't fit in a JSON export. Or just use it to remove some nested fields from a relation which was included in the export with the `--with-relationships` option.