### PR TITLE
Fix relationship import

### DIFF
--- a/src/Services/ImportService.php
+++ b/src/Services/ImportService.php
@@ -13,61 +13,46 @@ use Vildanbina\ModelJson\Traits\ImportingWithRelationships;
 
 /**
  * Class ImportService
- *
- * @package Vildanbina\ModelJson\Services
  */
 class ImportService extends JsonService
 {
-    use HasModel;
-    use HasFilename;
-    use HasDestinationPath;
     use ColumnManipulator;
     use DataManipulator;
-    use ImportingWithRelationships;
     use EachClosure;
+    use HasDestinationPath;
+    use HasFilename;
+    use HasModel;
+    use ImportingWithRelationships;
 
-    /**
-     * @var bool
-     */
     protected bool $updateWhenExists = false;
-    /**
-     * @var string|array|null
-     */
+
     protected null|string|array $updateKeys = [];
 
     /**
-     * @param  array|string|null  $updateKeys
-     *
      * @return $this
      */
     public function updateKeys(null|array|string $updateKeys = []): ImportService
     {
         $this->updateKeys = $updateKeys;
+
         return $this;
     }
 
     /**
-     * @param  bool  $updateWhenExists
-     *
      * @return $this
      */
     public function updateWhenExists(bool $updateWhenExists = true): static
     {
         $this->updateWhenExists = $updateWhenExists;
+
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getTotalModelsCount(): int
     {
         return count($this->getJsonAsArray());
     }
 
-    /**
-     * @return bool|string
-     */
     public function run(): bool|string
     {
         $data = $this->getJsonAsArray();
@@ -85,15 +70,20 @@ class ImportService extends JsonService
                 $item = Arr::except($item, static::$timestampsField);
             }
 
+            $relationships = is_array($this->getRelationships()) ? $this->getRelationships() : explode('+', $this->getRelationships());
+            $itemWithoutRelations = $this->getRelationships() !== null
+                ? Arr::except($item, $relationships)
+                : $item;
+
             if ($this->updateWhenExists) {
                 $updateKeys = filled($this->updateKeys) ? $this->updateKeys : (new $this->model)->getKeyName();
 
                 $model = $this->model::updateOrCreate(
-                    Arr::only($item, $updateKeys),
-                    Arr::except($item, $updateKeys),
+                    Arr::only($itemWithoutRelations, $updateKeys),
+                    Arr::except($itemWithoutRelations, $updateKeys),
                 );
             } else {
-                $model = $this->model::create($item);
+                $model = $this->model::create($itemWithoutRelations);
             }
 
             $this->importRelationships($model, $item, $this->getRelationships());


### PR DESCRIPTION
This fixes an issue when importing models with relationships from previously exported jsons. In the current implementation, relations are considered as fields, thus inserted into the database – which fails, as intended.

The proposed fix removes any relations set from the data used in for creating or updating the base model.